### PR TITLE
Fix header menu layout

### DIFF
--- a/chekmaket/style.css
+++ b/chekmaket/style.css
@@ -9,6 +9,7 @@ body{
     font-size: 20px;
     line-height: 24px;
     color: #FFFFFF;
+    margin: 0;
 }
 a{
     text-decoration: none;
@@ -35,15 +36,19 @@ padding: 0 10px;
     
 }
 .header_top{
+    height: 96px;
+    margin-left: -10px;
+    margin-right: -10px;
+    padding: 0 10px;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    flex-wrap: wrap;
+    column-gap: 36px;
     background-color: rgba(242, 120, 92, 0.7);
     background-size: cover;
 }
 .logo_img{
-    padding: 25px 158px 34px 0;
+
 }
 .header_login{
     font-size: 16px;
@@ -59,19 +64,14 @@ padding: 0 10px;
     border-radius: 10px;
 }
 .menu{
-    width: 100%;
-    border-top: 1px;
-    margin-top: 32px;
-    padding: 25px 120px 0 34px;
-    width: 527px;
-    height: 21px;
-    
+    margin-left: auto;
+    margin-right: auto;
 }
 .menu_list{
     display: flex;
-    justify-content: space-between;
+    column-gap: 24px;
+    flex-wrap: wrap;
     color:#FFFFFF;
-    
 }
 
 


### PR DESCRIPTION
В этом мерж реквесте я поправил только отображение меню. Стало выглядеть вот так:
![image](https://user-images.githubusercontent.com/8182743/176470696-12718296-40a4-42da-a782-422672e4f83b.png)

Какой тут в целом должен быть подход: оптимальный путь обычно - это когда мы хотим задать высоту хедера, какую нам надо, а контент хедера выстраивать просто по центру по вертикали (align-items: center;).

У тебя вероятно сложности еще возникли из-за того, что ты пыталась отцентровать меню в флекс-контейнере при помощи отступов. Дополнительно еще в мерж реквесте напишу комментарии к строчками с изменениями, чтоб было понятно что и зачем я менял.